### PR TITLE
Update configure

### DIFF
--- a/configure
+++ b/configure
@@ -6,6 +6,7 @@ import re
 import shlex
 import subprocess
 import sys
+import platform
 
 CC = os.environ.get('CC', 'cc')
 
@@ -420,6 +421,7 @@ def host_arch_cc():
       rtn = matchup[i]
       break
 
+  rtn = platform.machine()
   return rtn
 
 

--- a/configure
+++ b/configure
@@ -6,7 +6,6 @@ import re
 import shlex
 import subprocess
 import sys
-import platform
 
 CC = os.environ.get('CC', 'cc')
 
@@ -419,9 +418,11 @@ def host_arch_cc():
   for i in matchup:
     if i in k and k[i] != '0':
       rtn = matchup[i]
-      break
+      if (rtn == 's390'):
+        continue
+      else:
+        break
 
-  rtn = platform.machine()
   return rtn
 
 


### PR DESCRIPTION
After running './configure' on s390x architecture VM, I was getting following output:

bash-4.3# uname -rvmpio
3.10.0-229.1.2.el7.s390x #1 SMP Fri Mar 6 17:14:40 EST 2015 s390x s390x s390x GNU/Linux

bash-4.3# ./configure
{ 'target_defaults': { 'cflags': [],
                       'default_configuration': 'Release',
                       'defines': [],
                       'include_dirs': [],
                       'libraries': []},
  'variables': { 'clang': 0,
                 'gcc_version': 49,
                 'host_arch': 's390',
                 'node_byteorder': 'big',
                 'node_install_npm': 'true',
                 'node_prefix': '',
                 'node_shared_cares': 'false',
                 'node_shared_http_parser': 'false',
                 'node_shared_libuv': 'false',
                 'node_shared_openssl': 'false',
                 'node_shared_v8': 'false',
                 'node_shared_zlib': 'false',
                 'node_tag': '',
                 'node_unsafe_optimizations': 0,
                 'node_use_dtrace': 'false',
                 'node_use_etw': 'false',
                 'node_use_openssl': 'true',
                 'node_use_perfctr': 'false',
                 'node_use_systemtap': 'false',
                 'openssl_no_asm': 0,
                 'python': '/usr/bin/python',
                 'target_arch': 's390',
                 'v8_enable_gdbjit': 0,
                 'v8_no_strict_aliasing': 1,
                 'v8_use_snapshot': 'true',
                 'want_separate_host_toolset': 0}}
creating  ./config.gypi
creating  ./config.mk
bash-4.3#


As we could see, the configure script has returned me incorrect architecture i.e. 's390' instead of 's390x'. I got this behavior for Fedora21, RHEL7, SLES12 and MCP8 OS. This causes 'make' fail as it tries to build for 's390' instead on 's390x'.

I am proposing the mentioned changes for fixing the issue.

Below is the output when I run the updated './configure' script:

bash-4.3# ./configure
{ 'target_defaults': { 'cflags': [],
                       'default_configuration': 'Release',
                       'defines': [],
                       'include_dirs': [],
                       'libraries': []},
  'variables': { 'clang': 0,
                 'gcc_version': 49,
                 'host_arch': 's390x',
                 'node_byteorder': 'big',
                 'node_install_npm': 'true',
                 'node_prefix': '',
                 'node_shared_cares': 'false',
                 'node_shared_http_parser': 'false',
                 'node_shared_libuv': 'false',
                 'node_shared_openssl': 'false',
                 'node_shared_v8': 'false',
                 'node_shared_zlib': 'false',
                 'node_tag': '',
                 'node_unsafe_optimizations': 0,
                 'node_use_dtrace': 'false',
                 'node_use_etw': 'false',
                 'node_use_openssl': 'true',
                 'node_use_perfctr': 'false',
                 'node_use_systemtap': 'false',
                 'openssl_no_asm': 0,
                 'python': '/usr/bin/python',
                 'target_arch': 's390x',
                 'v8_enable_gdbjit': 0,
                 'v8_no_strict_aliasing': 1,
                 'v8_use_snapshot': 'true',
                 'want_separate_host_toolset': 0}}
creating  ./config.gypi
creating  ./config.mk
bash-4.3#

Now it correctly identifies the host architecture for s390x.

Thanks.