### PR TITLE
 Added for loop to Encode function in order to support big-endian machines

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -857,7 +857,17 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
                                  const uint16_t* buf,
                                  size_t buflen) {
   Local<String> val;
-
+  uint16_t dst[buflen];
+  if (IsBigEndian()) {
+    // Node's "ucs2" encoding expects LE character data inside a
+    // Buffer, so we need to reorder on BE platforms.  See
+    // http://nodejs.org/api/buffer.html regarding Node's "ucs2"
+    // encoding specification
+    for (size_t i = 0; i < buflen; i++) {
+      dst[i] = (buf[i] << 8) | (buf[i] >> 8);
+    }
+    buf = dst;
+  }
   if (buflen < EXTERN_APEX) {
     val = String::NewFromTwoByte(isolate,
                                  buf,


### PR DESCRIPTION
This for loop uses stack allocation rather than heap allocation to improve speed.