### PR TITLE
test: fix test-net-persistent-keepalive for AIX

### DIFF
--- a/test/parallel/test-net-persistent-keepalive.js
+++ b/test/parallel/test-net-persistent-keepalive.js
@@ -4,8 +4,17 @@ var assert = require('assert');
 var net = require('net');
 
 var serverConnection;
+var clientConnection;
 var echoServer = net.createServer(function(connection) {
   serverConnection = connection;
+  setTimeout(function() {
+    // make sure both connections are still open
+    assert.equal(serverConnection.readyState, 'open');
+    assert.equal(clientConnection.readyState, 'open');
+    serverConnection.end();
+    clientConnection.end();
+    echoServer.close();
+  }, 600);
   connection.setTimeout(0);
   assert.equal(typeof connection.setKeepAlive, 'function');
   connection.on('end', function() {
@@ -15,20 +24,11 @@ var echoServer = net.createServer(function(connection) {
 echoServer.listen(common.PORT);
 
 echoServer.on('listening', function() {
-  var clientConnection = new net.Socket();
+  clientConnection = new net.Socket();
   // send a keepalive packet after 1000 ms
   // and make sure it persists
   var s = clientConnection.setKeepAlive(true, 400);
   assert.ok(s instanceof net.Socket);
   clientConnection.connect(common.PORT);
   clientConnection.setTimeout(0);
-
-  setTimeout(function() {
-    // make sure both connections are still open
-    assert.equal(serverConnection.readyState, 'open');
-    assert.equal(clientConnection.readyState, 'open');
-    serverConnection.end();
-    clientConnection.end();
-    echoServer.close();
-  }, 600);
 });


### PR DESCRIPTION
Fixed an intermittent issue on AIX where the 600ms timeout was reached
before the 'connection' event was fired. This resulted in a failure as
serverConnection would be undefined and the assert.equal would throw an
error. Changed the flow of the test so that the timeout is only set
after a connection has been made.