### PR TITLE
test: Fix test-cluster-worker-exit.js for AIX

### DIFF
--- a/test/parallel/test-cluster-worker-exit.js
+++ b/test/parallel/test-cluster-worker-exit.js
@@ -60,8 +60,6 @@ if (cluster.isWorker) {
     results.cluster_exitCode = worker.process.exitCode;
     results.cluster_signalCode = worker.process.signalCode;
     results.cluster_emitExit += 1;
-    assert.ok(results.cluster_emitDisconnect,
-        "cluster: 'exit' event before 'disconnect' event");
   });
 
   // Check worker events and properties
@@ -69,6 +67,9 @@ if (cluster.isWorker) {
     results.worker_emitDisconnect += 1;
     results.worker_suicideMode = worker.suicide;
     results.worker_state = worker.state;
+    if (results.worker_emitExit > 0) {
+      process.nextTick(function() { finish_test(); });
+    }
   });
 
   // Check that the worker died
@@ -77,10 +78,9 @@ if (cluster.isWorker) {
     results.worker_signalCode = signalCode;
     results.worker_emitExit += 1;
     results.worker_died = !alive(worker.process.pid);
-    assert.ok(results.worker_emitDisconnect,
-        "worker: 'exit' event before 'disconnect' event");
-
-    process.nextTick(function() { finish_test(); });
+    if (results.worker_emitDisconnect > 0) {
+      process.nextTick(function() { finish_test(); });
+    }
   });
 
   var finish_test = function() {


### PR DESCRIPTION
test fails intermittently due to the assertion that the 'disconnect'
event should come before the 'exit' event. This is caused be the
non-deteministic behaviour of pollset_poll[1] on AIX
(see deps/uv/src/unix/aix.c). This API makes no garauntee for the order
in which file descriptors are returned. On linux epoll_wait[2] is used,
which also does not make a garauntee on order of file descriptors
returned. In the failing case we recieve our file descriptor with a
callback of uv__signal_event (which causes JavaScript to receive the
exit event) before our file descriptor with uv__stream_io as its
callback (which in turn causes JavaScript receive the disconnect event).
This change simply removes the assertion that the disconnect event
happens before exit event and processes the test regardless of which
event comes first.

[1] https://www-01.ibm.com/support/knowledgecenter/ssw_aix_71/com.ibm.ai
x.basetrf1/pollset.htm
[2] http://linux.die.net/man/2/epoll_pwait

PR-URL: https://github.com/nodejs/node/pull/3666
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>